### PR TITLE
Isolate libmpv builds from host system

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
+aar-output/
 .gdb_history
 bin
 gen

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,15 @@
+FROM mingc/android-build-box
+
+RUN apt update && apt upgrade -y
+
+RUN apt install -y git curl wget sudo
+
+COPY ./ /libmpv
+
+WORKDIR /libmpv/buildscripts
+
+RUN bash download.sh
+
+RUN bash patch.sh
+
+RUN bash build.sh mpv-android

--- a/buildscripts/docker-build.sh
+++ b/buildscripts/docker-build.sh
@@ -1,0 +1,5 @@
+#! /bin/bash
+
+docker build -t libmpv-android .
+
+docker run -it --rm -v ./aar-output:/output libmpv-android bash  -c "cp /libmpv/libmpv/build/outputs/aar/libmpv-release.aar /output/libmpv.aar"


### PR DESCRIPTION
Thank you for preparing this library.

I have used an older version of the precompiled AAR in one of my projects. If you are interested, I put together a small dockerfile and script. This generates the AAR from your repo without the host needing to have anything setup ahead of time.