### PR TITLE
feat: vulkan

### DIFF
--- a/buildscripts/build.sh
+++ b/buildscripts/build.sh
@@ -56,6 +56,9 @@ loadarch () {
 setup_prefix () {
 	if [ ! -d "$prefix_dir" ]; then
 		mkdir -p "$prefix_dir"
+		mkdir -p "$prefix_dir/lib"
+    mkdir -p "$prefix_dir/lib/pkgconfig"
+    mkdir -p "$prefix_dir/include"
 		# enforce flat structure (/usr/local -> /)
 		ln -s . "$prefix_dir/usr"
 		ln -s . "$prefix_dir/local"

--- a/buildscripts/include/depinfo.sh
+++ b/buildscripts/include/depinfo.sh
@@ -14,6 +14,7 @@ v_harfbuzz=11.2.1
 v_fribidi=1.0.16
 v_freetype=2-13-3
 v_mbedtls=3.6.4
+v_shaderc=2025.3
 v_libplacebo=7.351.0
 v_dav1d=1.5.1
 v_ffmpeg=7.1.1
@@ -31,7 +32,8 @@ dep_fribidi=()
 dep_harfbuzz=()
 dep_libass=(freetype fribidi harfbuzz)
 dep_lua=()
-dep_libplacebo=()
+dep_shaderc=()
+dep_libplacebo=(shaderc)
 dep_mpv=(ffmpeg libass lua libplacebo)
 dep_mpv_android=(mpv)
 

--- a/buildscripts/include/download-deps.sh
+++ b/buildscripts/include/download-deps.sh
@@ -34,6 +34,14 @@ if [ ! -d lua ]; then
 		tar -xz -C lua --strip-components=1
 fi
 
+# shaderc
+if [ ! -d shaderc ]; then
+	git clone --depth 1 --branch v$v_shaderc --recursive https://github.com/google/shaderc shaderc
+	cd shaderc/utils
+	./git-sync-deps
+	cd ../..
+fi
+
 [ ! -d libplacebo ] && git clone --depth 1 --branch v$v_libplacebo --recurse-submodules https://code.videolan.org/videolan/libplacebo.git libplacebo
 
 # mpv

--- a/buildscripts/scripts/libplacebo.sh
+++ b/buildscripts/scripts/libplacebo.sh
@@ -16,7 +16,7 @@ fi
 
 unset CC CXX
 meson setup $build --cross-file "$prefix_dir"/crossfile.txt \
-	-Dvulkan=disabled -Ddemos=false
+	-Dvk-proc-addr=enabled -Ddemos=false
 
 ninja -C $build -j$cores
 DESTDIR="$prefix_dir" ninja -C $build install

--- a/buildscripts/scripts/mpv.sh
+++ b/buildscripts/scripts/mpv.sh
@@ -14,11 +14,22 @@ else
 	exit 255
 fi
 
+# Android provides Vulkan, but no pkgconfig file
+# you can double-check the version in vk.xml (ctrl+f VK_API_VERSION)
+mkdir -p "$prefix_dir"/lib/pkgconfig
+cat >"$prefix_dir"/lib/pkgconfig/vulkan.pc <<"END"
+Name: Vulkan
+Description:
+Version: 1.3.0
+Libs: -lvulkan
+Cflags:
+END
+
 unset CC CXX # meson wants these unset
 
 meson setup $build --cross-file "$prefix_dir"/crossfile.txt \
 	--default-library shared \
-	-Diconv=disabled -Dlua=enabled \
+	-Diconv=disabled -Dlua=enabled -Dvulkan=enabled \
 	-Dlibmpv=true -Dcplayer=false \
 	-Dmanpage-build=disabled
 

--- a/buildscripts/scripts/shaderc.sh
+++ b/buildscripts/scripts/shaderc.sh
@@ -20,7 +20,6 @@ abi=armeabi-v7a
 [[ "$ndk_triple" == "i686"* ]] && abi=x86
 
 # build using the NDK's scripts, but keep object files in our build dir
-cd "$(dirname "$(which ndk-build)")/sources/third_party/shaderc"
 ndk-build -j$cores \
 	NDK_PROJECT_PATH=. APP_BUILD_SCRIPT=Android.mk \
 	APP_PLATFORM=android-26 APP_STL=c++_shared APP_ABI=$abi \
@@ -32,12 +31,14 @@ cp -r include/* "$prefix_dir/include"
 cp libs/*/$abi/libshaderc.a "$prefix_dir/lib/libshaderc_combined.a"
 
 # create a pkgconfig file
-# 'libc++' instead of 'libstdc++': workaround for meson linking bug
-mkdir -p "$prefix_dir"/lib/pkgconfig
-cat >"$prefix_dir"/lib/pkgconfig/shaderc_combined.pc <<"END"
+cat >"$prefix_dir"/lib/pkgconfig/shaderc_combined.pc <<END
+prefix=/usr/local
+includedir=\${prefix}/include
+libdir=\${prefix}/lib
+
 Name: shaderc_combined
-Description:
-Version: 2022.3-unknown
-Libs: -L/usr/lib -lshaderc_combined
-Cflags: -I/usr/include
+Description: A collection of tools, libraries, and tests for Vulkan shader compilation.
+Version: $v_shaderc
+Libs: -L\${libdir} -lshaderc_combined
+Cflags: -I\${includedir}
 END


### PR DESCRIPTION
# Vulkan support

The minimum supported Vulkan version is 1.2.

To use vulkan set the gpu context to `androidvk`.

## Tested devices

### Google Pixel 8
Software decoding works.
Hardware decoding `mediacodec` does **not** work and falls back to software decoding.
Hardware decoding `mediacodec-copy` works.

### Google Pixel 11 Pro
Software decoding works.
Hardware decoding `mediacodec` does **not** work and falls back to software decoding.
Hardware decoding `mediacodec-copy` works.

### Sony A95K
Does not work due to Vulkan version 1.1.

## HDR

I also tested some HDR10 files on my Google Pixel 8 and Pixel 11 Pro. Here are my findings.
To enable HDR use the following options `--vo=gpu-next --gpu-context=androidvk --target-colorspace-hint=yes`

### Hardware decoding
- `no` (software decoding) works without issues.
- `mediacodec` does not work, falls back to software.
- `mediacodec-copy` works but stutters and sometimes crashes.